### PR TITLE
Rename package to rdf-tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
-# rdf-to-ts
-Generate TypeScript from RDF.
+# rdf-tools
+Tools for RDF.
 
 ## Installation
 ```
-npm install -g rdf-to-ts
+npm install -g rdf-tools
 ```
 
 ## Usage
 ```
-rdf-to-ts --help
+rdf-tools --help
 ```
 
 ```
-Usage: dist [options] <pattern>
+Usage: rdf-tools [options] <pattern>
 
-Generate TypeScript from RDF
+Tools for RDF
 
 
 Options:
@@ -24,6 +24,7 @@ Options:
   -i, --iris             output IRIs
   -l, --literals         output literals
   -c, --classes          output classes
+  -t, --type-guards      output type guards
   -d, --default-exports  output default exports. Can only be used in combination with other flags
   -D, --debug            output debug information
   -h, --help             output usage information
@@ -32,7 +33,7 @@ Options:
 ## Example
 The following command will output types for all classes explicitly defined in the ontology, as well as an object containing the prefixes and IRIs used by the ontology.
 ```
-rdf-to-ts example.ttl > example.ts
+rdf-tools example.ttl > example.ts
 ```
 
 ## How does it work?

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "rdf-to-ts",
+  "name": "rdf-tools",
   "version": "0.3.0",
   "main": "dist/index.js",
   "author": "Steffan Sluis <steffansluis@gmail.com>",
   "license": "MIT",
   "bin": {
-    "rdf-to-ts": "dist/index.js"
+    "rdf-tools": "dist/index.js"
   },
   "scripts": {
     "dist": "tsc",
@@ -61,6 +61,6 @@
     "node": ">= 8",
     "npm": ">= 5"
   },
-  "description": "Generate TypeScript from RDF",
-  "repository": "git@github.com:knowledge-express/rdf-to-ts.git"
+  "description": "Tools for RDF",
+  "repository": "git@github.com:knowledge-express/rdf-tools.git"
 }


### PR DESCRIPTION
This PR renames the package to `rdf-tools`. In addition to bumping the minor version after releasing, the package will be re-published under the new name starting at the newly bumped version. The [old package](https://www.npmjs.com/package/rdf-to-ts) will be deprecated.